### PR TITLE
Add OIDC permissions for AWS authentication

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
     branches: [main, development]
 
+permissions:
+  contents: read
+  id-token: write
+
 env:
   NODE_VERSION: '20'
   ARTIFACT_NAME: musical-zoe-frontend
@@ -195,15 +199,15 @@ jobs:
               
               case "${STATUS}" in
                 "Success")
-                  echo "✅ Deployment completed successfully!"
+                  echo "Deployment completed successfully!"
                   exit 0
                   ;;
                 "Failed"|"Cancelled"|"TimedOut")
-                  echo "❌ Deployment failed with status: ${STATUS}"
+                  echo "Deployment failed with status: ${STATUS}"
                   exit 1
                   ;;
                 "InProgress")
-                  echo "⏳ Deployment in progress..."
+                  echo "Deployment in progress..."
                   sleep 30
                   ;;
                 *)

--- a/documentation/DEPLOYMENT_SETUP.md
+++ b/documentation/DEPLOYMENT_SETUP.md
@@ -7,32 +7,34 @@ This guide explains how to set up the automated deployment pipeline for Musical 
 The following secrets must be configured in your GitHub repository:
 
 ### AWS Configuration (OIDC)
+
 - `AWS_ROLE_ARN`: IAM role for GitHub Actions to assume (e.g., `arn:aws:iam::123456789012:role/GitHubActionsRole`)
 - `AWS_REGION`: AWS region where resources are deployed (e.g., `us-east-1`)
 
 **Note**: This workflow uses OpenID Connect (OIDC) for secure authentication with AWS. The IAM role must have a trust policy that allows GitHub Actions to assume it.
 
 ### Example IAM Role Trust Policy
+
 ```json
 {
-  "Version": "2012-10-17",
-  "Statement": [
-    {
-      "Effect": "Allow",
-      "Principal": {
-        "Federated": "arn:aws:iam::123456789012:oidc-provider/token.actions.githubusercontent.com"
-      },
-      "Action": "sts:AssumeRoleWithWebIdentity",
-      "Condition": {
-        "StringEquals": {
-          "token.actions.githubusercontent.com:aud": "sts.amazonaws.com"
-        },
-        "StringLike": {
-          "token.actions.githubusercontent.com:sub": "repo:Blue-Davinci/MusicalZoe-FE:*"
-        }
-      }
-    }
-  ]
+	"Version": "2012-10-17",
+	"Statement": [
+		{
+			"Effect": "Allow",
+			"Principal": {
+				"Federated": "arn:aws:iam::123456789012:oidc-provider/token.actions.githubusercontent.com"
+			},
+			"Action": "sts:AssumeRoleWithWebIdentity",
+			"Condition": {
+				"StringEquals": {
+					"token.actions.githubusercontent.com:aud": "sts.amazonaws.com"
+				},
+				"StringLike": {
+					"token.actions.githubusercontent.com:sub": "repo:Blue-Davinci/MusicalZoe-FE:*"
+				}
+			}
+		}
+	]
 }
 ```
 

--- a/documentation/DEPLOYMENT_SETUP.md
+++ b/documentation/DEPLOYMENT_SETUP.md
@@ -6,10 +6,35 @@ This guide explains how to set up the automated deployment pipeline for Musical 
 
 The following secrets must be configured in your GitHub repository:
 
-### AWS Configuration
-
+### AWS Configuration (OIDC)
 - `AWS_ROLE_ARN`: IAM role for GitHub Actions to assume (e.g., `arn:aws:iam::123456789012:role/GitHubActionsRole`)
 - `AWS_REGION`: AWS region where resources are deployed (e.g., `us-east-1`)
+
+**Note**: This workflow uses OpenID Connect (OIDC) for secure authentication with AWS. The IAM role must have a trust policy that allows GitHub Actions to assume it.
+
+### Example IAM Role Trust Policy
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "Federated": "arn:aws:iam::123456789012:oidc-provider/token.actions.githubusercontent.com"
+      },
+      "Action": "sts:AssumeRoleWithWebIdentity",
+      "Condition": {
+        "StringEquals": {
+          "token.actions.githubusercontent.com:aud": "sts.amazonaws.com"
+        },
+        "StringLike": {
+          "token.actions.githubusercontent.com:sub": "repo:Blue-Davinci/MusicalZoe-FE:*"
+        }
+      }
+    }
+  ]
+}
+```
 
 ### S3 Configuration
 


### PR DESCRIPTION
- Added id-token: write permission to workflow for OIDC authentication
- Added contents: read permission for repository access
- Updated deployment documentation with OIDC configuration requirements
- Added example IAM role trust policy for GitHub Actions OIDC

This fixes the AWS credentials error by enabling proper OIDC authentication between GitHub Actions and AWS services.

